### PR TITLE
Fix typo in word Separates

### DIFF
--- a/api/xml/Microsoft.AspNetCore.Http.Extensions/UriHelper.xml
+++ b/api/xml/Microsoft.AspNetCore.Http.Extensions/UriHelper.xml
@@ -144,7 +144,7 @@
         <param name="query">The query, if any.</param>
         <param name="fragment">The fragment, if any.</param>
         <summary>
-            Seperates the given absolute URI string into components. Assumes no PathBase.
+            Separates the given absolute URI string into components. Assumes no PathBase.
             </summary>
         <remarks>To be added.</remarks>
       </Docs>


### PR DESCRIPTION
seperates should be separates.