### PR TITLE
Corrects typo

### DIFF
--- a/api/xml/Microsoft.Extensions.Logging/ILogger`1.xml
+++ b/api/xml/Microsoft.Extensions.Logging/ILogger`1.xml
@@ -24,7 +24,7 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <typeparam name="TCategoryName">The type who's name is used for the logger category name.</typeparam>
+    <typeparam name="TCategoryName">The type whose name is used for the logger category name.</typeparam>
     <summary>
             A generic interface for logging where the category name is derived from the specified
             <typeparamref name="TCategoryName" /> type name.


### PR DESCRIPTION
Incorrect usage of "who's"; should be "whose" (https://www.grammarly.com/blog/whos-whose/).