### PR TITLE
Sort log levels by level instead of alphabetical

### DIFF
--- a/api/xml/Microsoft.Extensions.Logging/LogLevel.xml
+++ b/api/xml/Microsoft.Extensions.Logging/LogLevel.xml
@@ -21,12 +21,12 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
-    <Member MemberName="Critical">
-      <MemberSignature Language="C#" Value="Critical" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel Critical = int32(5)" />
-      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.Critical" />
-      <MemberSignature Language="VB.NET" Value="Critical" />
-      <MemberSignature Language="F#" Value="Critical = 5" Usage="Microsoft.Extensions.Logging.LogLevel.Critical" />
+    <Member MemberName="Trace">
+      <MemberSignature Language="C#" Value="Trace" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel Trace = int32(0)" />
+      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.Trace" />
+      <MemberSignature Language="VB.NET" Value="Trace" />
+      <MemberSignature Language="F#" Value="Trace = 0" Usage="Microsoft.Extensions.Logging.LogLevel.Trace" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
@@ -38,11 +38,11 @@
       <ReturnValue>
         <ReturnType>Microsoft.Extensions.Logging.LogLevel</ReturnType>
       </ReturnValue>
-      <MemberValue>5</MemberValue>
+      <MemberValue>0</MemberValue>
       <Docs>
         <summary>
-            Logs that describe an unrecoverable application or system crash, or a catastrophic failure that requires
-            immediate attention.
+            Logs that contain the most detailed messages. These messages may contain sensitive application data.
+            These messages are disabled by default and should never be enabled in a production environment.
             </summary>
       </Docs>
     </Member>
@@ -71,31 +71,6 @@
             </summary>
       </Docs>
     </Member>
-    <Member MemberName="Error">
-      <MemberSignature Language="C#" Value="Error" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel Error = int32(4)" />
-      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.Error" />
-      <MemberSignature Language="VB.NET" Value="Error" />
-      <MemberSignature Language="F#" Value="Error = 4" Usage="Microsoft.Extensions.Logging.LogLevel.Error" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyVersion>1.1.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <AssemblyVersion>2.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Microsoft.Extensions.Logging.LogLevel</ReturnType>
-      </ReturnValue>
-      <MemberValue>4</MemberValue>
-      <Docs>
-        <summary>
-            Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a
-            failure in the current activity, not an application-wide failure.
-            </summary>
-      </Docs>
-    </Member>
     <Member MemberName="Information">
       <MemberSignature Language="C#" Value="Information" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel Information = int32(2)" />
@@ -117,55 +92,6 @@
       <Docs>
         <summary>
             Logs that track the general flow of the application. These logs should have long-term value.
-            </summary>
-      </Docs>
-    </Member>
-    <Member MemberName="None">
-      <MemberSignature Language="C#" Value="None" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel None = int32(6)" />
-      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.None" />
-      <MemberSignature Language="VB.NET" Value="None" />
-      <MemberSignature Language="F#" Value="None = 6" Usage="Microsoft.Extensions.Logging.LogLevel.None" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyVersion>1.1.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <AssemblyVersion>2.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Microsoft.Extensions.Logging.LogLevel</ReturnType>
-      </ReturnValue>
-      <MemberValue>6</MemberValue>
-      <Docs>
-        <summary>
-            Not used for writing log messages. Specifies that a logging category should not write any messages.
-            </summary>
-      </Docs>
-    </Member>
-    <Member MemberName="Trace">
-      <MemberSignature Language="C#" Value="Trace" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel Trace = int32(0)" />
-      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.Trace" />
-      <MemberSignature Language="VB.NET" Value="Trace" />
-      <MemberSignature Language="F#" Value="Trace = 0" Usage="Microsoft.Extensions.Logging.LogLevel.Trace" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyVersion>1.1.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <AssemblyVersion>2.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Microsoft.Extensions.Logging.LogLevel</ReturnType>
-      </ReturnValue>
-      <MemberValue>0</MemberValue>
-      <Docs>
-        <summary>
-            Logs that contain the most detailed messages. These messages may contain sensitive application data.
-            These messages are disabled by default and should never be enabled in a production environment.
             </summary>
       </Docs>
     </Member>
@@ -191,6 +117,80 @@
         <summary>
             Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the
             application execution to stop.
+            </summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Error">
+      <MemberSignature Language="C#" Value="Error" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel Error = int32(4)" />
+      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.Error" />
+      <MemberSignature Language="VB.NET" Value="Error" />
+      <MemberSignature Language="F#" Value="Error = 4" Usage="Microsoft.Extensions.Logging.LogLevel.Error" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyVersion>1.1.0.0</AssemblyVersion>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+        <AssemblyVersion>2.1.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Extensions.Logging.LogLevel</ReturnType>
+      </ReturnValue>
+      <MemberValue>4</MemberValue>
+      <Docs>
+        <summary>
+            Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a
+            failure in the current activity, not an application-wide failure.
+            </summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Critical">
+      <MemberSignature Language="C#" Value="Critical" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel Critical = int32(5)" />
+      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.Critical" />
+      <MemberSignature Language="VB.NET" Value="Critical" />
+      <MemberSignature Language="F#" Value="Critical = 5" Usage="Microsoft.Extensions.Logging.LogLevel.Critical" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyVersion>1.1.0.0</AssemblyVersion>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+        <AssemblyVersion>2.1.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Extensions.Logging.LogLevel</ReturnType>
+      </ReturnValue>
+      <MemberValue>5</MemberValue>
+      <Docs>
+        <summary>
+            Logs that describe an unrecoverable application or system crash, or a catastrophic failure that requires
+            immediate attention.
+            </summary>
+      </Docs>
+    </Member>
+    <Member MemberName="None">
+      <MemberSignature Language="C#" Value="None" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Extensions.Logging.LogLevel None = int32(6)" />
+      <MemberSignature Language="DocId" Value="F:Microsoft.Extensions.Logging.LogLevel.None" />
+      <MemberSignature Language="VB.NET" Value="None" />
+      <MemberSignature Language="F#" Value="None = 6" Usage="Microsoft.Extensions.Logging.LogLevel.None" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyVersion>1.1.0.0</AssemblyVersion>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+        <AssemblyVersion>2.1.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Extensions.Logging.LogLevel</ReturnType>
+      </ReturnValue>
+      <MemberValue>6</MemberValue>
+      <Docs>
+        <summary>
+            Not used for writing log messages. Specifies that a logging category should not write any messages.
             </summary>
       </Docs>
     </Member>


### PR DESCRIPTION
Currently the log levels are shown in order alphabetically, which makes no sense and doesn't reflect the amount of messages shown. I reordered them so that they are in order from most messages (level 0 - Trace) to least messages (level 6 - None).