### PR TITLE
Document Microsoft.Extensions.PlatformAbstractions as deprecated

### DIFF
--- a/aspnet-core/xml/Microsoft.Extensions.PlatformAbstractions/ApplicationEnvironment.xml
+++ b/aspnet-core/xml/Microsoft.Extensions.PlatformAbstractions/ApplicationEnvironment.xml
@@ -14,8 +14,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>This type has been deprecated.</summary>
+    <remarks>Use equivalent .NET APIs instead.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -31,8 +31,8 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>This method has been deprecated.</summary>
+        <remarks>Use equivalent .NET APIs instead.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ApplicationBasePath">
@@ -51,9 +51,8 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>This property has been deprecated.</summary>
+        <remarks>Use System.AppContext.BaseDirectory or System.AppDomain.CurrentDomain.BaseDirectory instead.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ApplicationName">
@@ -72,9 +71,8 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>This property has been deprecated.</summary>
+        <remarks>Use System.Reflection.Assembly.GetEntryAssembly().GetName().Name or System.AppDomain.CurrentDomain.SetupInformation.ApplicationName instead.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ApplicationVersion">
@@ -93,9 +91,8 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>This property has been deprecated.</summary>
+        <remarks>Use System.Reflection.Assembly.GetEntryAssembly().GetName().Version instead.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RuntimeFramework">
@@ -114,9 +111,8 @@
         <ReturnType>System.Runtime.Versioning.FrameworkName</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>This property has been deprecated.</summary>
+        <remarks>Use System.Reflection.Assembly.GetEntryAssembly().GetCustomAttribute&lt;TargetFrameworkAttribute&gt;().FrameworkName or System.AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName instead.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/aspnet-core/xml/Microsoft.Extensions.PlatformAbstractions/PlatformServices.xml
+++ b/aspnet-core/xml/Microsoft.Extensions.PlatformAbstractions/PlatformServices.xml
@@ -14,8 +14,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>This type has been deprecated.</summary>
+    <remarks>Use equivalent .NET APIs instead.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Application">
@@ -34,9 +34,8 @@
         <ReturnType>Microsoft.Extensions.PlatformAbstractions.ApplicationEnvironment</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>This property has been deprecated.</summary>
+        <remarks>Use equivalent .NET APIs instead.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -55,9 +54,8 @@
         <ReturnType>Microsoft.Extensions.PlatformAbstractions.PlatformServices</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>This property has been deprecated.</summary>
+        <remarks>Use equivalent .NET APIs instead.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/aspnet-core/xml/ns-Microsoft.Extensions.PlatformAbstractions.xml
+++ b/aspnet-core/xml/ns-Microsoft.Extensions.PlatformAbstractions.xml
@@ -1,6 +1,6 @@
 <Namespace Name="Microsoft.Extensions.PlatformAbstractions">
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>This package has been deprecated.</summary>
+    <remarks>Use equivalent .NET APIs instead.</remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
Microsoft.Extensions.PlatformAbstractions is obsolete with better replacement, and it has bugs
that we are not planning to fix. Delete it from the official docs to limit its use for new code.

Related discussion: https://github.com/dotnet/coreclr/pull/22396