### PR TITLE
Fix typo in documentation of health status

### DIFF
--- a/aspnet-core/xml/Microsoft.Extensions.Diagnostics.HealthChecks/HealthStatus.xml
+++ b/aspnet-core/xml/Microsoft.Extensions.Diagnostics.HealthChecks/HealthStatus.xml
@@ -22,7 +22,7 @@
             developers may configure a health check to report a different status as desired.
             </para>
       <para>
-            The values of this enum or ordered from least healthy to most healthy. So <see cref="F:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded" /> is
+            The values of this enum are ordered from least healthy to most healthy. So <see cref="F:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded" /> is
             greater than <see cref="F:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy" /> but less than <see cref="F:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy" />.
             </para>
     </remarks>


### PR DESCRIPTION
Changing "The values of this enum or ordered[...]"
to "The values of this enum are ordered[...]"