### PR TITLE
Pull Request: Documentation Text Update in JwtBearerExtensions.xml

### DIFF
--- a/aspnet-core/xml/Microsoft.Extensions.DependencyInjection/JwtBearerExtensions.xml
+++ b/aspnet-core/xml/Microsoft.Extensions.DependencyInjection/JwtBearerExtensions.xml
@@ -74,7 +74,7 @@
         <summary>
             Enables JWT-bearer authentication using the default scheme <see cref="F:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults.AuthenticationScheme" />.
             <para>
-            JWT bearer authentication performs authentication by extracting and validating a JWT token from the <c>Authorization</c> request header.
+            JWT bearer authentication performs authentication by extracting and validating a JWT from the <c>Authorization</c> request header.
             </para></summary>
         <returns>A reference to <paramref name="builder" /> after the operation has completed.</returns>
         <remarks>To be added.</remarks>
@@ -114,7 +114,7 @@
         <summary>
             Enables JWT-bearer authentication using the default scheme <see cref="F:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults.AuthenticationScheme" />.
             <para>
-            JWT bearer authentication performs authentication by extracting and validating a JWT token from the <c>Authorization</c> request header.
+            JWT bearer authentication performs authentication by extracting and validating a JWT from the <c>Authorization</c> request header.
             </para></summary>
         <returns>A reference to <paramref name="builder" /> after the operation has completed.</returns>
         <remarks>To be added.</remarks>
@@ -147,7 +147,7 @@
         <summary>
             Enables JWT-bearer authentication using a pre-defined scheme.
             <para>
-            JWT bearer authentication performs authentication by extracting and validating a JWT token from the <c>Authorization</c> request header.
+            JWT bearer authentication performs authentication by extracting and validating a JWT from the <c>Authorization</c> request header.
             </para></summary>
         <returns>A reference to <paramref name="builder" /> after the operation has completed.</returns>
         <remarks>To be added.</remarks>
@@ -189,7 +189,7 @@
         <summary>
             Enables JWT-bearer authentication using the specified scheme.
             <para>
-            JWT bearer authentication performs authentication by extracting and validating a JWT token from the <c>Authorization</c> request header.
+            JWT bearer authentication performs authentication by extracting and validating a JWT from the <c>Authorization</c> request header.
             </para></summary>
         <returns>A reference to <paramref name="builder" /> after the operation has completed.</returns>
         <remarks>To be added.</remarks>
@@ -241,7 +241,7 @@
         <summary>
             Enables JWT-bearer authentication using the specified scheme.
             <para>
-            JWT bearer authentication performs authentication by extracting and validating a JWT token from the <c>Authorization</c> request header.
+            JWT bearer authentication performs authentication by extracting and validating a JWT from the <c>Authorization</c> request header.
             </para></summary>
         <returns>A reference to <paramref name="builder" /> after the operation has completed.</returns>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
**Pull Request:** Documentation Text Update in JwtBearerExtensions.xml
**Summary:**
This pull request updates the XML documentation in JwtBearerExtensions.xml by changing the phrase "JWT token" to simply "JWT" for improved technical accuracy and clarity.

**Rationale:**
The term "JWT token" is redundant, as JWT already stands for JSON Web Token. The updated text ensures consistency with standard terminology and aligns with best practices in authentication documentation.

**Example:**
**_Before:_** "JWT bearer authentication performs authentication by extracting and validating a JWT token from the Authorization request header."

**_After:_** "JWT bearer authentication performs authentication by extracting and validating a JWT from the Authorization request header."